### PR TITLE
Update jsdom to fix a dom parsing issue from html-encoding-sniffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Emmanuel Olaojo",
   "license": "MIT",
   "dependencies": {
-    "jsdom": "11.3.0"
+    "jsdom": "16.2.1"
   },
   "devDependencies": {
     "chai": "4.1.2",


### PR DESCRIPTION
There was a dom parsing issue that I reported here [Sometimes it doesn't return dom title in correct encoding format](https://github.com/jsdom/jsdom/issues/2766) has been [fixed and released](https://github.com/jsdom/html-encoding-sniffer/releases/tag/v2.0.0). 

We should update jsdom dependency to apply this fix and further resolved issues.